### PR TITLE
Add DistinctBy method

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,3 +30,11 @@ var batchSize = 5;
 
 var batches = source.Batch(batchSize);
 ```
+
+The DistinctBy() method takes an object property and returns a collection of objects which are distinct by that property.
+
+```c#
+var source = new HashSet<Person>();
+
+source.DistinctBy(o => o.Email)
+```

--- a/src/CollectionExtensions/CollectionExtensions.cs
+++ b/src/CollectionExtensions/CollectionExtensions.cs
@@ -50,12 +50,12 @@ namespace Enable.Extensions
             return allBatches;
         }
 
-        public static IEnumerable<T> DistinctBy<T, TProp>(this IEnumerable<T> source, Func<T, TProp> property)
+        public static List<T> DistinctBy<T, TProp>(this ICollection<T> source, Func<T, TProp> property)
         {
-            Argument.IsNotNull(source, "source");
-            Argument.IsNotNull(property, "property");
+            Argument.IsNotNull(source, nameof(source));
+            Argument.IsNotNull(property, nameof(property));
 
-            return source.GroupBy(property).Select(o => o.First());
+            return source.AsEnumerable().GroupBy(property).Select(o => o.First()).ToList();
         }
     }
 }

--- a/src/CollectionExtensions/CollectionExtensions.cs
+++ b/src/CollectionExtensions/CollectionExtensions.cs
@@ -49,5 +49,13 @@ namespace Enable.Extensions
 
             return allBatches;
         }
+
+        public static IEnumerable<T> DistinctBy<T, TProp>(this IEnumerable<T> source, Func<T, TProp> property)
+        {
+            Argument.IsNotNull(source, "source");
+            Argument.IsNotNull(property, "property");
+
+            return source.GroupBy(property).Select(o => o.First());
+        }
     }
 }

--- a/test/CollectionExtensions.Test/CollectionExtensionsDistinctByTests.cs
+++ b/test/CollectionExtensions.Test/CollectionExtensionsDistinctByTests.cs
@@ -1,0 +1,95 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using AutoFixture;
+using Xunit;
+
+namespace Enable.Extensions
+{
+    public class CollectionExtensionsDistinctByTests
+    {
+        private readonly Fixture _fixture;
+
+        public CollectionExtensionsDistinctByTests()
+        {
+            _fixture = new Fixture();
+        }
+
+        [Fact]
+        public void DistinctBy_ThrowsIfSourceIsNull()
+        {
+            // Arrange
+            IEnumerable<Person> source = null;
+            Func<Person, string> property = person => person.EmailAddress;
+
+            // Act
+            var action = new Action(() =>
+            {
+                source.DistinctBy(property);
+            });
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void DistinctBy_ThrowsIfPropertyIsNull()
+        {
+            // Arrange
+            IEnumerable<Person> source = _fixture.CreateMany<Person>();
+            Func<Person, string> property = null;
+
+            // Act
+            var action = new Action(() =>
+            {
+                source.DistinctBy(property);
+            });
+
+            // Assert
+            Assert.Throws<ArgumentNullException>(action);
+        }
+
+        [Fact]
+        public void DistinctBy_ReturnsAnUnchangedCollectionIfNoDuplicatePropertyValuesAreFound()
+        {
+            // Arrange
+            var source = _fixture.CreateMany<Person>();
+
+            // Act
+            var peopleWithDistinctEmailAddresses = source.DistinctBy(o => o.EmailAddress);
+
+            // Assert
+            Assert.Equal(source, peopleWithDistinctEmailAddresses);
+        }
+
+        [Fact]
+        public void DistinctBy_RemovesObjectsWhichHaveDuplicatePropertyValues()
+        {
+            // Arrange
+            var emailAddress = _fixture.Create<string>();
+
+            var source = new List<Person>
+            {
+                _fixture.Create<Person>(),
+                _fixture.Build<Person>().With(o => o.EmailAddress, emailAddress).Create(),
+                _fixture.Build<Person>().With(o => o.EmailAddress, emailAddress).Create()
+            };
+
+            // Act
+            var peopleWithDistinctEmailAddresses = source.DistinctBy(o => o.EmailAddress);
+
+            // Assert
+            foreach (var group in peopleWithDistinctEmailAddresses.GroupBy(o => o.EmailAddress))
+            {
+                Assert.Single(group);
+            }
+        }
+
+        private class Person
+        {
+            public int Id { get; set; }
+            public string Name { get; set; }
+            public string EmailAddress { get; set; }
+        }
+    }
+}

--- a/test/CollectionExtensions.Test/CollectionExtensionsDistinctByTests.cs
+++ b/test/CollectionExtensions.Test/CollectionExtensionsDistinctByTests.cs
@@ -19,7 +19,7 @@ namespace Enable.Extensions
         public void DistinctBy_ThrowsIfSourceIsNull()
         {
             // Arrange
-            IEnumerable<Person> source = null;
+            ICollection<Person> source = null;
             Func<Person, string> property = person => person.EmailAddress;
 
             // Act
@@ -36,7 +36,10 @@ namespace Enable.Extensions
         public void DistinctBy_ThrowsIfPropertyIsNull()
         {
             // Arrange
-            IEnumerable<Person> source = _fixture.CreateMany<Person>();
+            var source = _fixture
+                .CreateMany<Person>()
+                .ToArray();
+
             Func<Person, string> property = null;
 
             // Act
@@ -53,7 +56,7 @@ namespace Enable.Extensions
         public void DistinctBy_ReturnsAnUnchangedCollectionIfNoDuplicatePropertyValuesAreFound()
         {
             // Arrange
-            var source = _fixture.CreateMany<Person>();
+            var source = _fixture.CreateMany<Person>().ToArray();
 
             // Act
             var peopleWithDistinctEmailAddresses = source.DistinctBy(o => o.EmailAddress);
@@ -87,8 +90,6 @@ namespace Enable.Extensions
 
         private class Person
         {
-            public int Id { get; set; }
-            public string Name { get; set; }
             public string EmailAddress { get; set; }
         }
     }


### PR DESCRIPTION
This method will allow callers to filter a collection of objects, returning only objects which have a unique value for the selected property.

For example:

```csharp
public class Person
{
	public int Age { get; set; }
	public string EmailAddress { get; set; }
}

void Main()
{
	var people = new HashSet<Person>
	{
		new Person { Age = 20, EmailAddress = "test@email.com" },
		new Person { Age = 21, EmailAddress = "test2@email.com" },
		new Person { Age = 22, EmailAddress = "test@email.com" },
		new Person { Age = 25, EmailAddress = null },
		new Person { Age = 23, EmailAddress = null }
	};
		
	var result = people
		.DistinctBy(o => o.EmailAddress)
		.ToDictionary(o => o.Age, o => o.EmailAddress);
	
	// result
	// 20 | test@email.com
	// 21 | test2@email.com
	// 25 | null
}
```

Here the third and fifth have been removed because their email address value was a duplicate of a previous entries value.

